### PR TITLE
Add Streamlit inference app

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,11 @@ The resulting heatmap is stored in `outputs/visualizations/`.
 
 ---
 Created as a beginner-friendly yet medically relevant deep learning project.
+
+## Web App
+You can launch a simple Streamlit interface to test the model on your own images:
+
+```bash
+pip install -r requirements.txt
+streamlit run app.py
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,22 @@
+import streamlit as st
+from PIL import Image
+from src.inference import predict_image
+from main import load_config
+
+
+def main():
+    st.title("Chest X-ray Pneumonia Classifier")
+
+    uploaded_file = st.file_uploader("Upload X-ray Image", type=["png", "jpg", "jpeg"])
+    config = load_config()
+
+    if uploaded_file is not None:
+        image = Image.open(uploaded_file).convert("L")
+        st.image(image, caption="Uploaded Image", width=300)
+        if st.button("Predict"):
+            label = predict_image(image, config)
+            st.write(f"**Prediction:** {label}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ tqdm>=4.65.0
 opencv-python>=4.7.0
 pyyaml>=6.0
 jupyterlab>=3.6.0
+streamlit>=1.0

--- a/src/inference.py
+++ b/src/inference.py
@@ -1,0 +1,54 @@
+import os
+import torch
+from torchvision import transforms
+from PIL import Image
+
+from src.model import SimpleCNN
+
+
+def predict_image(img, config):
+    """Load model checkpoint and predict label for a single image.
+
+    Parameters
+    ----------
+    img : PIL.Image or torch.Tensor
+        Input image. If tensor, should be shape (1, H, W) in range [0, 1].
+    config : dict
+        Configuration dictionary containing at least 'checkpoint_dir'.
+
+    Returns
+    -------
+    str
+        Predicted label: 'NORMAL' or 'PNEUMONIA'.
+    """
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    checkpoint_path = os.path.join(config["checkpoint_dir"], "best_model.pth")
+    model = SimpleCNN().to(device)
+    model.load_state_dict(torch.load(checkpoint_path, map_location=device))
+    model.eval()
+
+    preprocess = transforms.Compose([
+        transforms.Resize((224, 224)),
+        transforms.ToTensor(),
+        transforms.Normalize([0.5], [0.5]),
+    ])
+
+    if isinstance(img, torch.Tensor):
+        tensor = img
+        if tensor.ndim == 3:  # (C,H,W) or (1,H,W)
+            pass
+        else:
+            raise ValueError("Tensor img must have shape (C,H,W)")
+        tensor = transforms.Normalize([0.5], [0.5])(tensor)
+    else:
+        img = img.convert("L")
+        tensor = preprocess(img)
+
+    tensor = tensor.unsqueeze(0).to(device)
+
+    with torch.no_grad():
+        outputs = model(tensor)
+        _, pred = torch.max(outputs, 1)
+
+    return "PNEUMONIA" if pred.item() == 1 else "NORMAL"

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,20 @@
+import pytest
+torch = pytest.importorskip("torch")
+from src.inference import predict_image
+from src.model import SimpleCNN
+
+
+def test_predict_image_returns_valid_label(tmp_path):
+    # create temporary checkpoint
+    ckpt_dir = tmp_path / "checkpoints"
+    ckpt_dir.mkdir()
+    ckpt_path = ckpt_dir / "best_model.pth"
+
+    model = SimpleCNN()
+    torch.save(model.state_dict(), ckpt_path)
+
+    dummy_img = torch.rand(1, 224, 224)  # single-channel tensor
+    config = {"checkpoint_dir": str(ckpt_dir)}
+
+    label = predict_image(dummy_img, config)
+    assert label in ["NORMAL", "PNEUMONIA"]


### PR DESCRIPTION
## Summary
- add `predict_image` helper for single-image inference
- create `app.py` to run a Streamlit UI
- support the app with `streamlit` dependency
- document how to run the web app
- provide a simple unit test for inference

## Testing
- `pytest -q` *(fails: 1 skipped due to missing torch)*